### PR TITLE
Windows API related codes are wrapped with if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) condition

### DIFF
--- a/source/Src/Logging/ExceptionFormatter.cs
+++ b/source/Src/Logging/ExceptionFormatter.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Specialized;
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Principal;
 using System.Text;
@@ -181,7 +182,10 @@ namespace Microsoft.Practices.EnterpriseLibrary.Logging
             this.additionalInfo.Add("TimeStamp:", "TimeStamp: " + DateTime.UtcNow.ToString(CultureInfo.CurrentCulture));
             this.additionalInfo.Add("FullName:", "FullName: " + Assembly.GetExecutingAssembly().FullName);
             this.additionalInfo.Add("AppDomainName:", "AppDomainName: " + AppDomain.CurrentDomain.FriendlyName);
-            this.additionalInfo.Add("WindowsIdentity:", "WindowsIdentity: " + GetWindowsIdentity());
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                this.additionalInfo.Add("WindowsIdentity:", "WindowsIdentity: " + GetWindowsIdentity());
+            }
         }
 
         private static string GetWindowsIdentity()

--- a/source/Src/Logging/LogEntry.cs
+++ b/source/Src/Logging/LogEntry.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Security;
 using System.Security.Permissions;
@@ -796,21 +797,42 @@ namespace Microsoft.Practices.EnterpriseLibrary.Logging
         [SecurityCritical]
         private static string GetProcessName()
         {
-            StringBuilder buffer = new StringBuilder(1024);
-            int length = NativeMethods.GetModuleFileName(NativeMethods.GetModuleHandle(null), buffer, buffer.Capacity);
-            return buffer.ToString();
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                StringBuilder buffer = new StringBuilder(1024);
+                int length = NativeMethods.GetModuleFileName(NativeMethods.GetModuleHandle(null), buffer, buffer.Capacity);
+                return buffer.ToString();
+            }
+            else
+            {
+                return Process.GetCurrentProcess().ProcessName.ToString(NumberFormatInfo.InvariantInfo);
+            }
         }
 
         [SecurityCritical]
         private static string GetCurrentProcessId()
         {
-            return NativeMethods.GetCurrentProcessId().ToString(NumberFormatInfo.InvariantInfo);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return NativeMethods.GetCurrentProcessId().ToString(NumberFormatInfo.InvariantInfo);
+            }
+            else
+            {
+                return Process.GetCurrentProcess().Id.ToString(NumberFormatInfo.InvariantInfo);
+            }
         }
 
         [SecurityCritical]
         private static string GetCurrentThreadId()
         {
-            return NativeMethods.GetCurrentThreadId().ToString(NumberFormatInfo.InvariantInfo);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return NativeMethods.GetCurrentThreadId().ToString(NumberFormatInfo.InvariantInfo);
+            }
+            else
+            {
+                return Thread.CurrentThread.ManagedThreadId.ToString(NumberFormatInfo.InvariantInfo);
+            }
         }
     }
 }

--- a/source/Src/Logging/Logging.csproj
+++ b/source/Src/Logging/Logging.csproj
@@ -32,6 +32,7 @@
 
     <PackageReference Include="Newtonsoft.Json" Version="12.0.*" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard')) OR $(TargetFramework.StartsWith('netcoreapp'))">

--- a/source/Tests/Logging/LogEntryFixture.cs
+++ b/source/Tests/Logging/LogEntryFixture.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using Microsoft.Practices.EnterpriseLibrary.Logging.Formatters;
@@ -155,7 +156,14 @@ namespace Microsoft.Practices.EnterpriseLibrary.Logging.Tests
 
             Assert.AreEqual(Environment.MachineName, log.MachineName);
             Assert.AreEqual(AppDomain.CurrentDomain.FriendlyName, log.AppDomainName);
-            Assert.AreEqual(NativeMethods.GetCurrentProcessId().ToString(), log.ProcessId);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.AreEqual(NativeMethods.GetCurrentProcessId().ToString(NumberFormatInfo.InvariantInfo), log.ProcessId);
+            }
+            else
+            {
+                Assert.AreEqual(Thread.CurrentThread.ManagedThreadId.ToString(NumberFormatInfo.InvariantInfo), log.ProcessId);
+            }
             Assert.AreEqual(GetExpectedProcessName(), log.ProcessName);
             Assert.AreEqual(Thread.CurrentThread.Name, log.ManagedThreadName);
             Assert.AreEqual(NativeMethods.GetCurrentThreadId().ToString(), log.Win32ThreadId);


### PR DESCRIPTION
Windows API related codes are wrapped with if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) condition.
Tested with .net core 3.1 on Linux and Windows Environments.