### PR TITLE
Output path for Debug configuration fixed. Was pointing to a local D …

### DIFF
--- a/source/Src/Logging/Logging.csproj
+++ b/source/Src/Logging/Logging.csproj
@@ -121,7 +121,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>D:\Projects\ConvertedEntlib\logging\source\..\bin\Debug\</OutputPath>
+    <OutputPath>$(SolutionDir)..\bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE;WMINET10</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
An output directory for a Logging project was pointing to a local D drive, making a project in general non-compilable.